### PR TITLE
Add methods to change the Bing Ads API environment

### DIFF
--- a/BingAds-Auth.md
+++ b/BingAds-Auth.md
@@ -23,3 +23,7 @@ Use `https://login.microsoftonline.com/common/oauth2/nativeclient` for the Redir
 ## (3) Generate Refresh Token
 
 [Back to Readme](README.md)
+
+## Sandbox
+
+The [Bing Ads API Sandbox](https://docs.microsoft.com/en-us/advertising/guides/sandbox?view=bingads-13) can be used by changing the API environment using the `->setEnvironment()` function.

--- a/src/Services/BingAds/Service.php
+++ b/src/Services/BingAds/Service.php
@@ -47,6 +47,8 @@ class Service
      *
      */
     protected $config;
+    
+    protected $environment = ApiEnvironment::Production;
 
     /**
      * with()
@@ -95,6 +97,32 @@ class Service
     {
         return $this->customerId;
     }
+    
+    /**
+     * setEnvironment()
+     *
+     * Sets the Bing API environment
+     *
+     * @return self
+     */
+    public function setEnvironment($env)
+    {
+        $this->environment = $env;
+        
+        return $this;
+    }
+    
+    /**
+     * getEnvironment()
+     *
+     * Get the current Bing API environment
+     *
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
 
     /**
      * fetch()
@@ -113,7 +141,7 @@ class Service
      */
     public function call($service)
     {
-        $serviceClient = (new ServiceClient($service, $this->session(), 'Production'));
+        $serviceClient = (new ServiceClient($service, $this->session(), $this->environment));
         $serviceClient->SetAuthorizationData($this->session());
 
         return $serviceClient;


### PR DESCRIPTION
As requested by me in #13, this PR adds a method to change the Bing Ads API environment to the Sandbox environment.

It can be used like:
```
$bing->setEnvironment('Sandbox');
```