### PR TITLE
Update composer for Google Ads v49

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 
 	"require": {
 		"php": ">=7",
-		"googleads/googleads-php-lib": "^47.0",
+		"googleads/googleads-php-lib": "^49.0",
 		"microsoft/bingads": "^0.12"
 	},
 


### PR DESCRIPTION
This allows using Guzzle v7. There are no Adwords changes affected by upgrading.

https://github.com/googleads/googleads-php-lib/releases/tag/49.0.0
https://github.com/googleads/googleads-php-lib/releases/tag/48.0.0