### PR TITLE
Url encode spaces

### DIFF
--- a/src/Console/RefreshTokenCommand.php
+++ b/src/Console/RefreshTokenCommand.php
@@ -136,7 +136,7 @@ class RefreshTokenCommand extends Command {
             ->withDeveloperToken($developerToken);
 
         $this->comment("Please sign in to your Bing Ads account, and open following url:");
-        $this->line($AuthorizationData->Authentication->GetAuthorizationEndpoint());
+        $this->line(str_replace(' ', '%20', $AuthorizationData->Authentication->GetAuthorizationEndpoint()));
 
         $accessToken = $this->ask('Insert the full URL that you were redirected to (after you approve the access):');
 


### PR DESCRIPTION
When the scope is `https://ads.microsoft.com/ads.manage offline_access` some IDE's don't allow for clicking the whole url.