### PR TITLE
Bump Facebook Ads SKD

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"php": ">=7",
 		"googleads/googleads-php-lib": "^49.0",
 		"microsoft/bingads": "^0.12",
-		"facebook/php-business-sdk": "^11.0"
+		"facebook/php-business-sdk": "^12.0"
 	},
 
 	"require-dev": {


### PR DESCRIPTION
This PR bumps the Facebook Ads SDK version from v11.0 to v12.0