### PR TITLE
Bug-fix bingads random report-id name extension

### DIFF
--- a/src/Services/BingAds/ReportDownload.php
+++ b/src/Services/BingAds/ReportDownload.php
@@ -129,8 +129,8 @@ class ReportDownload
             unlink($location);
         }
 
-		// Sometimes the .csv file has a name extension starting with _
-		// if this occurs we will just remove the extension.
+		// Sometimes the report id has a extension starting with _
+		// if this occurs we will just remove it.
 		$fileNameLength = strpos($name, '_') > 0 ? strpos($name, '_') : strlen($name);
 		$filePath = storage_path('app/') . substr($name, 0, $fileNameLength) . '.csv';
 

--- a/src/Services/BingAds/ReportDownload.php
+++ b/src/Services/BingAds/ReportDownload.php
@@ -129,9 +129,13 @@ class ReportDownload
             unlink($location);
         }
 
-        $data = file(storage_path('app/').$name.'.csv');
+		// Sometimes the .csv file has a name extension starting with _
+		// if this occurs we will just remove the extension.
+		$fileNameLength = strpos($name, '_') > 0 ? strpos($name, '_') : strlen($name);
+		$filePath = storage_path('app/') . substr($name, 0, $fileNameLength) . '.csv';
 
-        unlink(storage_path('app/').$name.'.csv');
+		$data = file($filePath);
+        unlink($filePath);
 
         return $data;
     }

--- a/src/Services/BingAds/ReportDownload.php
+++ b/src/Services/BingAds/ReportDownload.php
@@ -133,9 +133,12 @@ class ReportDownload
 		// if this occurs we will just remove it.
 		$fileNameLength = strpos($name, '_') > 0 ? strpos($name, '_') : strlen($name);
 		$filePath = storage_path('app/') . substr($name, 0, $fileNameLength) . '.csv';
-
-		$data = file($filePath);
-        unlink($filePath);
+		
+		try {
+    		$data = file($filePath);
+		} finally {
+    		unlink($filePath);
+		}
 
         return $data;
     }


### PR DESCRIPTION
Recently some reportIds from BingAds have had a name extension added to them. Instead of just eg, 620468266971 the reportId has been 620468266971_1649084551519 which causes issues when trying to open the file.

This bug-fix will remove everything that should not be in the reportId.
620468266971_1649084551519 -> 620468266971

This could probably be done in a nicer way, but I had to rush it as it is affecting our day-day business.