### PR TITLE
Upgrade Facebook API to Version 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"php": ">=7",
 		"googleads/googleads-php-lib": "^49.0",
 		"microsoft/bingads": "^0.12",
-		"facebook/php-business-sdk": "^12.0"
+		"facebook/php-business-sdk": "^13.0"
 	},
 
 	"require-dev": {


### PR DESCRIPTION
When trying to run `getAccountReport` on the Facebook service you get `You are calling a deprecated version of the Ads API. Please update to the latest version: v13.0`.

This pull requests make version v13.0 the lowest allowed API Version, which fixes the above issue.