### PR TITLE
Upgrade Bing Ads SDK version to 13.0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"php": ">=7",
 		"googleads/googleads-php-lib": "^49.0",
-		"microsoft/bingads": "^0.12",
+		"microsoft/bingads": "^13.0.13",
 		"facebook/php-business-sdk": "^13.0"
 	},
 


### PR DESCRIPTION
This library currently has a dependency on "^0.12" for the MS Ads SDK but Microsoft changed their versioning to drop the "0." prefix for versions. Due to this change, this library doesn't currently use the latest version and won't receive the changes.

## Why is this important?

The Bing Ads API will require 2FA authentification for using the API starting in June (https://docs.microsoft.com/en-us/advertising/guides/authentication-oauth-mfa?view=bingads-13). To support this change, the authentication needs the scope "msads.manage" instead of the old "ads.manage". Currently, this library uses an old version of the MS Ads SDK which still uses the old "ads.manage" scope:

![image](https://user-images.githubusercontent.com/10333196/168068623-93b190b8-ac2c-43f2-8ca7-2e0b0789fd31.png)

After the upgrade the generated URL will use the updated scope:

![image](https://user-images.githubusercontent.com/10333196/168068846-a61d05ea-a41f-40eb-937f-55937efd8f89.png)

## Testing

I tested this change locally using my existing report creator script.
