### PR TITLE
Bump Facebook Business SDK version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": ">=7",
 		"googleads/googleads-php-lib": "^60.0",
-		"microsoft/bingads": "^13.0.13",
+		"microsoft/bingads": "13.0.15.2",
 		"facebook/php-business-sdk": "^17.0"
 	},
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"php": ">=7",
 		"googleads/googleads-php-lib": "^49.0",
 		"microsoft/bingads": "^13.0.13",
-		"facebook/php-business-sdk": "^13.0"
+		"facebook/php-business-sdk": "^15.0"
 	},
 
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
 	"name": "tmarois/laravel-ads-sdk",
 	"homepage": "https://github.com/tmarois/laravel-ads-sdk",
 	"type": "package",
+	"minimum-stability": "stable",
 	"authors": [
         {
             "name": "Timothy Marois",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
 	"require": {
 		"php": ">=7",
+		"googleads/googleads-php-lib": "^60.0",
 		"microsoft/bingads": "^13.0.13",
 		"facebook/php-business-sdk": "^15.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"php": ">=7",
 		"googleads/googleads-php-lib": "^60.0",
 		"microsoft/bingads": "^13.0.13",
-		"facebook/php-business-sdk": "^15.0"
+		"facebook/php-business-sdk": "^17.0"
 	},
 
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
 	"require": {
 		"php": ">=7",
-		"googleads/googleads-php-lib": "^49.0",
 		"microsoft/bingads": "^13.0.13",
 		"facebook/php-business-sdk": "^15.0"
 	},


### PR DESCRIPTION
After receiving a notice that Facebook will begin deprecating any requests from versions 14 and under beginning January 25 2023, this should be updated asap to remain current.